### PR TITLE
ロゴのリンク先を yamap.com から corporate.yamap.co.jp に変更しました

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -154,7 +154,7 @@
                   </a>
                 </span>
                 <span class="w-45 center dib pa2 mv1 v-mid sponsorLogoBkg h-100">
-                  <a class="no-underline" href="https://yamap.com/" target="_blank" rel="noopener">
+                  <a class="no-underline" href="https://corporate.yamap.co.jp/" target="_blank" rel="noopener">
                     <img src="/assets/images/sponsors/yamap-logo.png" alt="yamap">
                   </a>
                 </span>


### PR DESCRIPTION
* ロゴのリンク先を yamap.com から corporate.yamap.co.jp に変更しました
